### PR TITLE
Remove branch ID field from registration form

### DIFF
--- a/fe-admin/src/pages/auth/Register.jsx
+++ b/fe-admin/src/pages/auth/Register.jsx
@@ -102,12 +102,7 @@ export default function Register() {
                 onChange={e => setAddress(e.target.value)}
                 required
               />
-              <TextField
-                label="Mã chi nhánh"
-                value={branchId}
-                onChange={e => setBranchId(e.target.value)}
-                required
-              />
+          
               <Button type="submit" variant="contained" color="primary">
                 Đăng ký
               </Button>


### PR DESCRIPTION
The 'Mã chi nhánh' (branch ID) input field has been removed from the registration form in Register.jsx. This simplifies the form and may reflect a change in registration requirements.